### PR TITLE
Add home page with hero and social tabs

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,12 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.6.0",
     "@testing-library/user-event": "^13.5.0",
+    "@emotion/react": "^11.11.1",
+    "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.14.0",
+    "@mui/material": "^5.14.9",
+    "@radix-ui/react-icons": "^1.3.0",
+    "@radix-ui/react-tabs": "^1.0.5",
     "react": "^18.3.1",
     "react-calendly": "^4.3.1",
     "react-dom": "^18.3.1",

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import Navbar from './components/Navbar';
 import About from './pages/About';
 import BookNow from './pages/BookNow';
 import Projects from './pages/Projects';
+import Home from './pages/Home';
 import Footer from './components/Footer';
 
 function App() {
@@ -13,9 +14,10 @@ function App() {
         <Navbar />
         <main>
           <Routes>
+          <Route path="/" element={<Home />} />
           <Route path="/booknow" element={<BookNow />} />
-            <Route path="/about" element={<About />} />
-            <Route path="/projects" element={<Projects />} />
+          <Route path="/about" element={<About />} />
+          <Route path="/projects" element={<Projects />} />
           </Routes>
         </main>
         <Footer/>

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+
+const Hero = () => (
+  <Box sx={{ textAlign: 'center', py: 8, backgroundColor: '#f5f5f5' }}>
+    <Typography variant="h3" component="h1" gutterBottom>
+      Welcome to Juangunner4
+    </Typography>
+    <Typography variant="h6" gutterBottom>
+      Follow my journey as a software engineer and footballer
+    </Typography>
+    <Button variant="contained" color="primary" href="/projects">
+      View Projects
+    </Button>
+  </Box>
+);
+
+export default Hero;

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -28,6 +28,7 @@ const Navbar = () => {
       </div>
 
       <div className={`navbar-right ${isMobileMenuOpen ? 'show' : ''}`}>
+        <Link to="/" >Home</Link>
         <Link to="/booknow" >Book Now</Link>
         <Link to="/about" >About</Link>
         <Link to="/projects" >Projects</Link>

--- a/src/components/__tests__/Hero.test.js
+++ b/src/components/__tests__/Hero.test.js
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import Hero from '../Hero';
+
+test('renders hero section', () => {
+  render(<Hero />);
+  expect(screen.getByText(/welcome to juangunner4/i)).toBeInTheDocument();
+});

--- a/src/components/__tests__/SocialTabs.test.js
+++ b/src/components/__tests__/SocialTabs.test.js
@@ -1,0 +1,9 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import SocialTabs from '../socials/SocialTabs';
+
+test('switches tabs', () => {
+  render(<SocialTabs />);
+  expect(screen.getByText(/follow me on x/i)).toBeInTheDocument();
+  fireEvent.click(screen.getByRole('tab', { name: /instagram/i }));
+  expect(screen.getByText(/follow me on instagram/i)).toBeInTheDocument();
+});

--- a/src/components/socials/InstagramFeed.js
+++ b/src/components/socials/InstagramFeed.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import Link from '@mui/material/Link';
+import { Instagram } from '@mui/icons-material';
+
+const InstagramFeed = () => (
+  <Card sx={{ my: 2 }}>
+    <CardContent sx={{ textAlign: 'center' }}>
+      <Instagram color="primary" sx={{ fontSize: 40 }} />
+      <Typography variant="h6">Follow me on Instagram</Typography>
+      <Link href="https://www.instagram.com/juangunner4" target="_blank" rel="noopener noreferrer">
+        @juangunner4
+      </Link>
+    </CardContent>
+  </Card>
+);
+
+export default InstagramFeed;

--- a/src/components/socials/SocialTabs.js
+++ b/src/components/socials/SocialTabs.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import * as Tabs from '@radix-ui/react-tabs';
+import Box from '@mui/material/Box';
+import Tab from '@mui/material/Tab';
+import TabsList from '@mui/material/Tabs';
+import XFeed from './XFeed';
+import InstagramFeed from './InstagramFeed';
+import TwitchFeed from './TwitchFeed';
+import YoutubeFeed from './YoutubeFeed';
+
+const SocialTabs = () => (
+  <Tabs.Root defaultValue="x">
+    <Tabs.List asChild>
+      <TabsList component={Box} sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <Tabs.Trigger value="x" asChild>
+          <Tab label="X" />
+        </Tabs.Trigger>
+        <Tabs.Trigger value="instagram" asChild>
+          <Tab label="Instagram" />
+        </Tabs.Trigger>
+        <Tabs.Trigger value="twitch" asChild>
+          <Tab label="Twitch" />
+        </Tabs.Trigger>
+        <Tabs.Trigger value="youtube" asChild>
+          <Tab label="YouTube" />
+        </Tabs.Trigger>
+      </TabsList>
+    </Tabs.List>
+    <Tabs.Content value="x">
+      <XFeed />
+    </Tabs.Content>
+    <Tabs.Content value="instagram">
+      <InstagramFeed />
+    </Tabs.Content>
+    <Tabs.Content value="twitch">
+      <TwitchFeed />
+    </Tabs.Content>
+    <Tabs.Content value="youtube">
+      <YoutubeFeed />
+    </Tabs.Content>
+  </Tabs.Root>
+);
+
+export default SocialTabs;

--- a/src/components/socials/TwitchFeed.js
+++ b/src/components/socials/TwitchFeed.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import Link from '@mui/material/Link';
+import { SportsEsports } from '@mui/icons-material';
+
+const TwitchFeed = () => (
+  <Card sx={{ my: 2 }}>
+    <CardContent sx={{ textAlign: 'center' }}>
+      <SportsEsports color="primary" sx={{ fontSize: 40 }} />
+      <Typography variant="h6">Watch me on Twitch</Typography>
+      <Link href="https://twitch.tv/juangunner4" target="_blank" rel="noopener noreferrer">
+        twitch.tv/juangunner4
+      </Link>
+    </CardContent>
+  </Card>
+);
+
+export default TwitchFeed;

--- a/src/components/socials/XFeed.js
+++ b/src/components/socials/XFeed.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import Link from '@mui/material/Link';
+import { Twitter } from '@mui/icons-material';
+
+const XFeed = () => (
+  <Card sx={{ my: 2 }}>
+    <CardContent sx={{ textAlign: 'center' }}>
+      <Twitter color="primary" sx={{ fontSize: 40 }} />
+      <Typography variant="h6">Follow me on X</Typography>
+      <Link href="https://twitter.com/juangunner4" target="_blank" rel="noopener noreferrer">
+        @juangunner4
+      </Link>
+    </CardContent>
+  </Card>
+);
+
+export default XFeed;

--- a/src/components/socials/YoutubeFeed.js
+++ b/src/components/socials/YoutubeFeed.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import Link from '@mui/material/Link';
+import { YouTube } from '@mui/icons-material';
+
+const YoutubeFeed = () => (
+  <Card sx={{ my: 2 }}>
+    <CardContent sx={{ textAlign: 'center' }}>
+      <YouTube color="primary" sx={{ fontSize: 40 }} />
+      <Typography variant="h6">Subscribe on YouTube</Typography>
+      <Link href="https://www.youtube.com/@juangunner4" target="_blank" rel="noopener noreferrer">
+        @juangunner4
+      </Link>
+    </CardContent>
+  </Card>
+);
+
+export default YoutubeFeed;

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import Hero from '../components/Hero';
+import SocialTabs from '../components/socials/SocialTabs';
+
+const Home = () => (
+  <div className="home-page">
+    <Hero />
+    <SocialTabs />
+  </div>
+);
+
+export default Home;


### PR DESCRIPTION
## Summary
- use Material UI and Radix UI packages
- add Hero component and SocialTabs with feeds for X, Instagram, Twitch and YouTube
- create Home page with new components
- update Navbar with Home link
- wire up home route
- add unit tests for Hero and SocialTabs

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460709a838832aafc8fbabb879ef41