### PR TITLE
Improve mobile nav drawer and match hero color

### DIFF
--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -4,7 +4,7 @@ import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 
 const Hero = () => (
-  <Box sx={{ textAlign: 'center', py: 8, backgroundColor: '#f5f5f5' }}>
+  <Box sx={{ textAlign: 'center', py: 8, backgroundColor: '#ff0000', color: 'white' }}>
     <Typography variant="h3" component="h1" gutterBottom>
       Welcome to Juangunner4
     </Typography>

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,19 +1,23 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
+import Drawer from '@mui/material/Drawer';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemText from '@mui/material/ListItemText';
 import '../styles/Navbar.css';
 import web2Image from '../assets/profile.png';
 import web3Image from '../assets/web3.jpg';
 
 const Navbar = () => {
   const [currentImage, setCurrentImage] = useState(web2Image);
-  const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
 
   const toggleProfileImage = () => {
     setCurrentImage((prevImage) => (prevImage === web2Image ? web3Image : web2Image));
   };
 
-  const toggleMobileMenu = () => {
-    setMobileMenuOpen((prev) => !prev);
+  const toggleDrawer = (open) => () => {
+    setDrawerOpen(open);
   };
 
   return (
@@ -27,19 +31,33 @@ const Navbar = () => {
         />
       </div>
 
-      <div className={`navbar-right ${isMobileMenuOpen ? 'show' : ''}`}>
+      <div className="navbar-right">
         <Link to="/" >Home</Link>
         <Link to="/booknow" >Book Now</Link>
         <Link to="/about" >About</Link>
         <Link to="/projects" >Projects</Link>
       </div>
 
-      <button className="hamburger" onClick={toggleMobileMenu}>
+      <button className="hamburger" onClick={toggleDrawer(true)}>
         ☰
       </button>
 
-
-      {isMobileMenuOpen && <div className="mobile-overlay" onClick={toggleMobileMenu}></div>}
+      <Drawer anchor="left" open={drawerOpen} onClose={toggleDrawer(false)}>
+        <List>
+          <ListItem button component={Link} to="/" onClick={toggleDrawer(false)}>
+            <ListItemText primary="Home" />
+          </ListItem>
+          <ListItem button component={Link} to="/booknow" onClick={toggleDrawer(false)}>
+            <ListItemText primary="Book Now" />
+          </ListItem>
+          <ListItem button component={Link} to="/about" onClick={toggleDrawer(false)}>
+            <ListItemText primary="About" />
+          </ListItem>
+          <ListItem button component={Link} to="/projects" onClick={toggleDrawer(false)}>
+            <ListItemText primary="Projects" />
+          </ListItem>
+        </List>
+      </Drawer>
     </nav>
   );
 };

--- a/src/styles/Navbar.css
+++ b/src/styles/Navbar.css
@@ -51,42 +51,6 @@
     cursor: pointer;
 }
 
-.mobile-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-    z-index: 999;
-}
-
-.navbar-right.show {
-    display: flex;
-    flex-direction: column;
-    position: absolute;
-    top: 60px;
-    right: 10px;
-    background-color: #FF0000;
-    padding: 15px;
-    border-radius: 8px;
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-    z-index: 1000;
-    gap: 10px;
-}
-
-.navbar-right.show a {
-    color: white;
-    text-decoration: none;
-    font-size: 18px;
-    padding: 5px 10px;
-    border-radius: 4px;
-    transition: background-color 0.3s ease;
-}
-
-.navbar-right.show a:hover {
-    background-color: rgba(255, 255, 255, 0.2);
-}
 
 @media (max-width: 768px) {
     .navbar-right {


### PR DESCRIPTION
## Summary
- use red hero section that matches the site's branding
- add Material UI drawer for navigation on mobile
- clean up navbar styles for the new drawer

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68460aa28a70832aae8e59eba80b6127