### PR TITLE
Implement web3 profile toggling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,23 +6,26 @@ import BookNow from './pages/BookNow';
 import Projects from './pages/Projects';
 import Home from './pages/Home';
 import Footer from './components/Footer';
+import { ProfileProvider } from './ProfileContext';
 
 function App() {
   return (
-    <Router>
-      <div className="App">
-        <Navbar />
-        <main>
-          <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/booknow" element={<BookNow />} />
-          <Route path="/about" element={<About />} />
-          <Route path="/projects" element={<Projects />} />
-          </Routes>
-        </main>
-        <Footer/>
-      </div>
-    </Router>
+    <ProfileProvider>
+      <Router>
+        <div className="App">
+          <Navbar />
+          <main>
+            <Routes>
+              <Route path="/" element={<Home />} />
+              <Route path="/booknow" element={<BookNow />} />
+              <Route path="/about" element={<About />} />
+              <Route path="/projects" element={<Projects />} />
+            </Routes>
+          </main>
+          <Footer />
+        </div>
+      </Router>
+    </ProfileProvider>
   );
 }
 

--- a/src/ProfileContext.js
+++ b/src/ProfileContext.js
@@ -1,0 +1,18 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const ProfileContext = createContext();
+
+export const ProfileProvider = ({ children }) => {
+  const [isWeb3, setIsWeb3] = useState(false);
+
+  const toggleProfile = () => setIsWeb3((prev) => !prev);
+
+  return (
+    <ProfileContext.Provider value={{ isWeb3, toggleProfile }}>
+      {children}
+    </ProfileContext.Provider>
+  );
+};
+
+export const useProfile = () => useContext(ProfileContext);
+

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -4,26 +4,33 @@ import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import '../styles/Hero.css';
+import { useProfile } from '../ProfileContext';
 
-const Hero = () => (
-  <Box className="hero-container">
-    <Typography variant="h3" component="h1" gutterBottom className="hero-title">
-      Welcome
-    </Typography>
-    <Typography variant="h6" gutterBottom className="hero-subtitle">
-      My name is Juan I enjoy{' '}
-      <span className="coding">programming</span>,{' '}
-      <span className="crypto"><i className="fab fa-bitcoin" /> crypto</span>, and{' '}
-      <span className="football"><i className="fas fa-futbol" /> football</span>.
-    </Typography>
-    <Button
-      variant="contained"
-      href="/projects"
-      className="project-button"
-    >
-      View Projects
-    </Button>
-  </Box>
-);
+const Hero = () => {
+  const { isWeb3 } = useProfile();
+
+  return (
+    <Box className="hero-container">
+      <Typography variant="h3" component="h1" gutterBottom className="hero-title">
+        Welcome
+      </Typography>
+      {isWeb3 ? (
+        <Typography variant="h6" gutterBottom className="hero-subtitle">
+          I enjoy memes and trolling.
+        </Typography>
+      ) : (
+        <Typography variant="h6" gutterBottom className="hero-subtitle">
+          My name is Juan I enjoy{' '}
+          <span className="coding">programming</span>,{' '}
+          <span className="crypto"><i className="fab fa-bitcoin" /> crypto</span>, and{' '}
+          <span className="football"><i className="fas fa-futbol" /> football</span>.
+        </Typography>
+      )}
+      <Button variant="contained" href="/projects" className="project-button">
+        View Projects
+      </Button>
+    </Box>
+  );
+};
 
 export default Hero;

--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -7,14 +7,12 @@ import ListItemText from '@mui/material/ListItemText';
 import '../styles/Navbar.css';
 import web2Image from '../assets/profile.png';
 import web3Image from '../assets/web3.jpg';
+import { useProfile } from '../ProfileContext';
 
 const Navbar = () => {
-  const [currentImage, setCurrentImage] = useState(web2Image);
+  const { isWeb3, toggleProfile } = useProfile();
+  const currentImage = isWeb3 ? web3Image : web2Image;
   const [drawerOpen, setDrawerOpen] = useState(false);
-
-  const toggleProfileImage = () => {
-    setCurrentImage((prevImage) => (prevImage === web2Image ? web3Image : web2Image));
-  };
 
   const toggleDrawer = (open) => () => {
     setDrawerOpen(open);
@@ -27,7 +25,7 @@ const Navbar = () => {
           src={currentImage}
           alt="Profile"
           className="navbar-pfp"
-          onClick={toggleProfileImage}
+          onClick={toggleProfile}
         />
       </div>
 

--- a/src/components/__tests__/Hero.test.js
+++ b/src/components/__tests__/Hero.test.js
@@ -1,8 +1,13 @@
 import { render, screen } from '@testing-library/react';
 import Hero from '../Hero';
+import { ProfileProvider } from '../../ProfileContext';
 
 test('renders hero section', () => {
-  render(<Hero />);
+  render(
+    <ProfileProvider>
+      <Hero />
+    </ProfileProvider>
+  );
   expect(screen.getByText(/welcome/i)).toBeInTheDocument();
   expect(screen.getByText(/my name is juan/i)).toBeInTheDocument();
 });

--- a/src/components/__tests__/SocialTabs.test.js
+++ b/src/components/__tests__/SocialTabs.test.js
@@ -1,8 +1,13 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import SocialTabs from '../socials/SocialTabs';
+import { ProfileProvider } from '../../ProfileContext';
 
 test('switches tabs', () => {
-  render(<SocialTabs />);
+  render(
+    <ProfileProvider>
+      <SocialTabs />
+    </ProfileProvider>
+  );
   expect(screen.getByText(/follow me on x/i)).toBeInTheDocument();
   fireEvent.click(screen.getByRole('tab', { name: /instagram/i }));
   expect(screen.getByText(/follow me on instagram/i)).toBeInTheDocument();

--- a/src/components/socials/XFeed.js
+++ b/src/components/socials/XFeed.js
@@ -4,17 +4,23 @@ import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import Link from '@mui/material/Link';
 import { Twitter } from '@mui/icons-material';
+import { useProfile } from '../../ProfileContext';
 
-const XFeed = () => (
-  <Card sx={{ my: 2 }}>
-    <CardContent sx={{ textAlign: 'center' }}>
-      <Twitter sx={{ fontSize: 40, color: '#ff0000' }} />
-      <Typography variant="h6">Follow me on X</Typography>
-      <Link href="https://twitter.com/juangunner4" target="_blank" rel="noopener noreferrer">
-        @juangunner4
-      </Link>
-    </CardContent>
-  </Card>
-);
+const XFeed = () => {
+  const { isWeb3 } = useProfile();
+  const handle = isWeb3 ? '0x1Juangunner4' : 'juangunner4';
+
+  return (
+    <Card sx={{ my: 2 }}>
+      <CardContent sx={{ textAlign: 'center' }}>
+        <Twitter sx={{ fontSize: 40, color: '#ff0000' }} />
+        <Typography variant="h6">Follow me on X</Typography>
+        <Link href={`https://twitter.com/${handle}`} target="_blank" rel="noopener noreferrer">
+          @{handle}
+        </Link>
+      </CardContent>
+    </Card>
+  );
+};
 
 export default XFeed;


### PR DESCRIPTION
## Summary
- implement a shared `ProfileContext`
- wrap app in the provider
- toggle profile in navbar
- update hero text and X handle based on profile type
- adjust tests for context

## Testing
- `npm test --silent -- -u --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68465853413c832aa16416973cf85b59