### PR TITLE
Make socials full-width on desktop

### DIFF
--- a/src/components/socials/InstagramFeed.js
+++ b/src/components/socials/InstagramFeed.js
@@ -6,7 +6,7 @@ import Link from '@mui/material/Link';
 import { Instagram } from '@mui/icons-material';
 
 const InstagramFeed = () => (
-  <Card sx={{ my: 2 }}>
+  <Card sx={{ my: 2, width: '100%' }}>
     <CardContent sx={{ textAlign: 'center' }}>
       <Instagram sx={{ fontSize: 40, color: '#ff0000' }} />
       <Typography variant="h6">Follow me on Instagram</Typography>

--- a/src/components/socials/SocialTabs.js
+++ b/src/components/socials/SocialTabs.js
@@ -9,9 +9,9 @@ import TwitchFeed from './TwitchFeed';
 import YoutubeFeed from './YoutubeFeed';
 
 const SocialTabs = () => (
-  <Tabs.Root defaultValue="x">
+  <Tabs.Root defaultValue="x" style={{ width: '100%' }}>
     <Tabs.List asChild>
-      <TabsList component={Box} sx={{ borderBottom: 1, borderColor: 'divider' }}>
+      <TabsList component={Box} sx={{ borderBottom: 1, borderColor: 'divider', width: '100%' }}>
         <Tabs.Trigger value="x" asChild>
           <Tab label="X" />
         </Tabs.Trigger>
@@ -26,16 +26,16 @@ const SocialTabs = () => (
         </Tabs.Trigger>
       </TabsList>
     </Tabs.List>
-    <Tabs.Content value="x">
+    <Tabs.Content value="x" style={{ width: '100%' }}>
       <XFeed />
     </Tabs.Content>
-    <Tabs.Content value="instagram">
+    <Tabs.Content value="instagram" style={{ width: '100%' }}>
       <InstagramFeed />
     </Tabs.Content>
-    <Tabs.Content value="twitch">
+    <Tabs.Content value="twitch" style={{ width: '100%' }}>
       <TwitchFeed />
     </Tabs.Content>
-    <Tabs.Content value="youtube">
+    <Tabs.Content value="youtube" style={{ width: '100%' }}>
       <YoutubeFeed />
     </Tabs.Content>
   </Tabs.Root>

--- a/src/components/socials/TwitchFeed.js
+++ b/src/components/socials/TwitchFeed.js
@@ -6,7 +6,7 @@ import Link from '@mui/material/Link';
 import { SportsEsports } from '@mui/icons-material';
 
 const TwitchFeed = () => (
-  <Card sx={{ my: 2 }}>
+  <Card sx={{ my: 2, width: '100%' }}>
     <CardContent sx={{ textAlign: 'center' }}>
       <SportsEsports sx={{ fontSize: 40, color: '#ff0000' }} />
       <Typography variant="h6">Watch me on Twitch</Typography>

--- a/src/components/socials/XFeed.js
+++ b/src/components/socials/XFeed.js
@@ -11,7 +11,7 @@ const XFeed = () => {
   const handle = isWeb3 ? '0x1Juangunner4' : 'juangunner4';
 
   return (
-    <Card sx={{ my: 2 }}>
+    <Card sx={{ my: 2, width: '100%' }}>
       <CardContent sx={{ textAlign: 'center' }}>
         <Twitter sx={{ fontSize: 40, color: '#ff0000' }} />
         <Typography variant="h6">Follow me on X</Typography>

--- a/src/components/socials/YoutubeFeed.js
+++ b/src/components/socials/YoutubeFeed.js
@@ -6,7 +6,7 @@ import Link from '@mui/material/Link';
 import { YouTube } from '@mui/icons-material';
 
 const YoutubeFeed = () => (
-  <Card sx={{ my: 2 }}>
+  <Card sx={{ my: 2, width: '100%' }}>
     <CardContent sx={{ textAlign: 'center' }}>
       <YouTube sx={{ fontSize: 40, color: '#ff0000' }} />
       <Typography variant="h6">Subscribe on YouTube</Typography>

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -39,7 +39,7 @@ const experiences = [
     title: "Head Youth Soccer Coach",
     company: "Villarreal CF, SAD",
     location: "Falls Church, Virginia, United States",
-    date: "Apr 2023 - Present",
+    date: "Apr 2023 - Apr 2025",
     description:
       "2015, 2016, and 2017 Boys Director and Coach. Junior Academy Director and Coach.",
     skills: ["Sports Coaching", "Athletics", "Soccer"],


### PR DESCRIPTION
## Summary
- stretch Socials tab layout to fill the screen
- make each social feed card use full width
- update Villarreal coaching end date in About page

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684759c349bc832a9d8d5b43f9d8549c