### PR TITLE
Add development environment selection

### DIFF
--- a/src/pages/Projects.js
+++ b/src/pages/Projects.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import '../styles/Projects.css';
 import * as Tabs from '@radix-ui/react-tabs';
 import Box from '@mui/material/Box';
@@ -20,68 +20,126 @@ const projectData = [
 const devProjectData = [
   {
     name: 'Primos NFT Marketplace',
-    devUrl: 'https://primos-marketplace.vercel.app/',
-    testUrl: 'https://primos-marketplace.onrender.com/',
+    logo: 'https://primos-marketplace.vercel.app/favicon.ico',
+    tags: ['web3', 'frontend', 'backend'],
+    environments: {
+      dev: 'https://primos-marketplace.vercel.app/',
+      test: 'https://primos-marketplace.onrender.com/',
+    },
   },
 ];
 
 const Projects = () => {
+  const [view, setView] = useState('production');
+  const [openProject, setOpenProject] = useState(null);
+
   return (
     <div className="projects-page">
       <h2>Projects</h2>
-      <div className="projects-container">
-        {projectData.map((project, index) => (
-          <div key={index} className="project-card">
-            <a href={`https://${project.domain}`} target="_blank" rel="noopener noreferrer" className="project-link">
-              <img
-                src={project.logo ? project.logo : `https://${project.domain}/favicon.ico`}
-                alt={`${project.domain} favicon`}
-                className="project-favicon"
-              />
-              <h3>{project.domain}</h3>
-            </a>
-            <div className="tags">
-              {project.tags.map((tag, i) => (
-                <span key={i} className="tag">{tag}</span>
-              ))}
+      <div className="event-buttons">
+        <button
+          className={`event-btn ${view === 'production' ? 'active' : ''}`}
+          onClick={() => setView('production')}
+        >
+          Production
+        </button>
+        <button
+          className={`event-btn ${view === 'development' ? 'active' : ''}`}
+          onClick={() => setView('development')}
+        >
+          In Development
+        </button>
+      </div>
+      {view === 'production' && (
+        <div className="projects-container">
+          {projectData.map((project, index) => (
+            <div key={index} className="project-card">
+              <a
+                href={`https://${project.domain}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="project-link"
+              >
+                <img
+                  src={project.logo ? project.logo : `https://${project.domain}/favicon.ico`}
+                  alt={`${project.domain} favicon`}
+                  className="project-favicon"
+                />
+                <h3>{project.domain}</h3>
+              </a>
+              <div className="tags">
+                {project.tags.map((tag, i) => (
+                  <span key={i} className="tag">{tag}</span>
+                ))}
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
-      <h2>In Development</h2>
-      <div className="dev-projects-container">
-        {devProjectData.map((project, index) => (
-          <Card key={index} className="dev-project-card" sx={{ minWidth: 275 }}>
-            <CardContent>
-              <Typography variant="h6" gutterBottom>
-                {project.name}
-              </Typography>
-              <Tabs.Root defaultValue="dev">
-                <Tabs.List asChild>
-                  <TabsList component={Box} sx={{ borderBottom: 1, borderColor: 'divider', mb: 1 }}>
-                    <Tabs.Trigger value="dev" asChild>
-                      <Tab label="Dev" />
-                    </Tabs.Trigger>
-                    <Tabs.Trigger value="test" asChild>
-                      <Tab label="Test" />
-                    </Tabs.Trigger>
-                  </TabsList>
-                </Tabs.List>
-                <Tabs.Content value="dev">
-                  <Button variant="outlined" href={project.devUrl} target="_blank" rel="noopener noreferrer">
-                    Visit Dev
-                  </Button>
-                </Tabs.Content>
-                <Tabs.Content value="test">
-                  <Button variant="outlined" href={project.testUrl} target="_blank" rel="noopener noreferrer">
-                    Visit Test
-                  </Button>
-                </Tabs.Content>
-              </Tabs.Root>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
+          ))}
+        </div>
+      )}
+
+      {view === 'development' && (
+        <div className="projects-container">
+          {devProjectData.map((project, index) => (
+            <div
+              key={index}
+              className="project-card"
+              onClick={() =>
+                setOpenProject(openProject === index ? null : index)
+              }
+            >
+              <div className="project-link">
+                <img
+                  src={project.logo}
+                  alt={`${project.name} logo`}
+                  className="project-favicon"
+                />
+                <h3>{project.name}</h3>
+              </div>
+              <div className="tags">
+                {project.tags.map((tag, i) => (
+                  <span key={i} className="tag">{tag}</span>
+                ))}
+              </div>
+              {openProject === index && (
+                <div className="dev-env-tabs">
+                  <Tabs.Root defaultValue="dev">
+                    <Tabs.List asChild>
+                      <TabsList component={Box} sx={{ borderBottom: 1, borderColor: 'divider', mb: 1 }}>
+                        <Tabs.Trigger value="dev" asChild>
+                          <Tab label="Dev" />
+                        </Tabs.Trigger>
+                        <Tabs.Trigger value="test" asChild>
+                          <Tab label="Test" />
+                        </Tabs.Trigger>
+                      </TabsList>
+                    </Tabs.List>
+                    <Tabs.Content value="dev">
+                      <Button
+                        variant="outlined"
+                        href={project.environments.dev}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Visit Dev
+                      </Button>
+                    </Tabs.Content>
+                    <Tabs.Content value="test">
+                      <Button
+                        variant="outlined"
+                        href={project.environments.test}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Visit Test
+                      </Button>
+                    </Tabs.Content>
+                  </Tabs.Root>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/styles/Projects.css
+++ b/src/styles/Projects.css
@@ -4,6 +4,34 @@
   color: #333;
 }
 
+.event-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin-bottom: 20px;
+}
+
+.event-btn {
+  background-color: #ff0000;
+  color: black;
+  border: none;
+  padding: 10px 20px;
+  font-size: 16px;
+  cursor: pointer;
+  border-radius: 5px;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+.event-btn.active {
+  background-color: #000;
+  color: #ff0000;
+}
+
+.event-btn:hover {
+  background-color: #000;
+  color: white;
+}
+
 .projects-container {
   display: flex;
   flex-wrap: wrap;
@@ -80,14 +108,7 @@
   opacity: 1 !important;
 }
 
-.dev-projects-container {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 20px;
-  justify-content: center;
-  margin-top: 20px;
-}
 
-.dev-project-card {
-  width: 300px;
+.dev-env-tabs {
+  margin-top: 10px;
 }


### PR DESCRIPTION
## Summary
- allow switching between production and in-development projects
- show environment options on project card click
- add styles for selection buttons and tabs

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f66fa7454832a89c403e9776ab855