### PR TITLE
Adjust side panel style

### DIFF
--- a/src/styles/Projects.css
+++ b/src/styles/Projects.css
@@ -125,10 +125,9 @@
 
 .side-panel {
   position: fixed;
-  top: 0;
-  right: 0;
-  width: 250px;
-  height: 100%;
+  top: 100px;
+  right: 20px;
+  width: 200px;
   background: #fff;
   box-shadow: -2px 0 8px rgba(0, 0, 0, 0.1);
   padding: 20px;


### PR DESCRIPTION
## Summary
- tweak Projects side panel to be a smaller popup positioned next to the card

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68603c2888d8832a86c8e535cd8880cb