### PR TITLE
Fix npm install by adjusting dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,12 +19,12 @@
         "@testing-library/user-event": "^13.5.0",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
-        "i18next": "^25.3.0",
+        "i18next": "23.16.8",
         "node-fetch": "^2.7.0",
         "react": "^18.3.1",
         "react-calendly": "^4.3.1",
         "react-dom": "^18.3.1",
-        "react-i18next": "^15.6.0",
+        "react-i18next": "14.0.8",
         "react-router-dom": "^6.27.0",
         "react-scripts": "5.0.1",
         "react-twitter-embed": "^4.0.4",
@@ -34,7 +34,8 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.6",
         "@testing-library/react": "^16.0.0",
-        "concurrently": "^9.2.0"
+        "concurrently": "^9.2.0",
+        "typescript": "~4.9.5"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -4425,6 +4426,17 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.23.tgz",
+      "integrity": "sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.12",
@@ -9538,9 +9550,9 @@
       }
     },
     "node_modules/i18next": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.3.0.tgz",
-      "integrity": "sha512-ZSQIiNGfqSG6yoLHaCvrkPp16UejHI8PCDxFYaNG/1qxtmqNmqEg4JlWKlxkrUmrin2sEjsy+Mjy1TRozBhOgw==",
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
       "funding": [
         {
           "type": "individual",
@@ -9557,15 +9569,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.6"
-      },
-      "peerDependencies": {
-        "typescript": "^5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iconv-lite": {
@@ -14234,27 +14238,23 @@
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
     "node_modules/react-i18next": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.6.0.tgz",
-      "integrity": "sha512-W135dB0rDfiFmbMipC17nOhGdttO5mzH8BivY+2ybsQBbXvxWIwl3cmeH3T9d+YPBSJu/ouyJKFJTtkK7rJofw==",
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-14.0.8.tgz",
+      "integrity": "sha512-1HKM41/Q8c/nQ2rYNNZlFmrjF2aubZT8sMBmY9aH/xa1/gsrTZ+hPwuLv4V7Cr8fYIh0GQ7vv5C1jCx104uNig==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.27.6",
+        "@babel/runtime": "^7.23.9",
         "html-parse-stringify": "^3.0.1"
       },
       "peerDependencies": {
         "i18next": ">= 23.2.3",
-        "react": ">= 16.8.0",
-        "typescript": "^5"
+        "react": ">= 16.8.0"
       },
       "peerDependenciesMeta": {
         "react-dom": {
           "optional": true
         },
         "react-native": {
-          "optional": true
-        },
-        "typescript": {
           "optional": true
         }
       }
@@ -17463,6 +17463,19 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "@testing-library/user-event": "^13.5.0",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
-    "i18next": "^25.3.0",
+    "i18next": "23.16.8",
     "node-fetch": "^2.7.0",
     "react": "^18.3.1",
     "react-calendly": "^4.3.1",
     "react-dom": "^18.3.1",
-    "react-i18next": "^15.6.0",
+    "react-i18next": "14.0.8",
     "react-router-dom": "^6.27.0",
     "react-scripts": "5.0.1",
     "react-twitter-embed": "^4.0.4",
@@ -56,6 +56,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.6",
     "@testing-library/react": "^16.0.0",
-    "concurrently": "^9.2.0"
+    "concurrently": "^9.2.0",
+    "typescript": "~4.9.5"
   }
 }


### PR DESCRIPTION
## Summary
- fix `npm install` by downgrading `i18next` and `react-i18next`
- pin TypeScript 4.9.5 for compatibility with `react-scripts`

## Testing
- `npm install`
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_686762f80f48832aa36fb41bada780a5