### PR TITLE
Fix build error by naming locale exports

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -1,4 +1,4 @@
-export default {
+const en = {
   navbar: {
     home: 'Home',
     bookNow: 'Book Now',
@@ -59,3 +59,5 @@ export default {
     contact: 'Contact:'
   }
 };
+
+export default en;

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -1,4 +1,4 @@
-export default {
+const es = {
   navbar: {
     home: 'Inicio',
     bookNow: 'Reservar',
@@ -59,3 +59,5 @@ export default {
     contact: 'Contacto:'
   }
 };
+
+export default es;


### PR DESCRIPTION
## Summary
- fix ESLint `import/no-anonymous-default-export` error by naming locale objects before exporting

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867c0b95400832a95050b9215888853