### PR TITLE
Add mobile language buttons to navbar

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -31,6 +31,15 @@ const Navbar = () => {
         />
       </div>
 
+      <div className="mobile-lang">
+        <button onClick={() => i18n.changeLanguage('en')} className="lang-btn">
+          {t('navbar.langEn')}
+        </button>
+        <button onClick={() => i18n.changeLanguage('es')} className="lang-btn">
+          {t('navbar.langEs')}
+        </button>
+      </div>
+
       <div className="navbar-right">
         <Link to="/" >{t('navbar.home')}</Link>
         <Link to="/booknow" >{t('navbar.bookNow')}</Link>

--- a/src/components/__tests__/Navbar.test.js
+++ b/src/components/__tests__/Navbar.test.js
@@ -30,6 +30,6 @@ test('opens drawer when hamburger clicked', () => {
 
 test('language buttons present', () => {
   setup();
-  expect(screen.getByRole('button', { name: /english/i })).toBeInTheDocument();
-  expect(screen.getByRole('button', { name: /español/i })).toBeInTheDocument();
+  expect(screen.getAllByRole('button', { name: /english/i }).length).toBeGreaterThan(0);
+  expect(screen.getAllByRole('button', { name: /español/i }).length).toBeGreaterThan(0);
 });

--- a/src/styles/Navbar.css
+++ b/src/styles/Navbar.css
@@ -38,7 +38,7 @@
     font-size: 18px;
 }
 
-.navbar-right .lang-btn {
+.lang-btn {
     background: transparent;
     border: 1px solid white;
     color: white;
@@ -62,6 +62,10 @@
     cursor: pointer;
 }
 
+.mobile-lang {
+    display: none;
+}
+
 
 @media (max-width: 768px) {
     .navbar-right {
@@ -70,5 +74,15 @@
 
     .hamburger {
         display: block;
+    }
+
+    .mobile-lang {
+        display: flex;
+        flex: 1;
+        justify-content: center;
+    }
+
+    .mobile-lang .lang-btn {
+        margin: 0 5px;
     }
 }


### PR DESCRIPTION
## Summary
- include a new `mobile-lang` section in the navbar so language buttons show on small screens
- style mobile language buttons for center placement
- update Navbar test to account for multiple language buttons

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6867c803bfa8832a84bc2f0ef7ea0d3d