### PR TITLE
Add X API tweet metrics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project was bootstrapped with [Create React App](https://github.com/faceboo
 
 ## API integration
 
-An Express server in `server.js` proxies requests to Twitter, Instagram, Twitch and YouTube APIs. Copy `.env.example` to `.env` and provide the credentials for each service.
+An Express server in `server/index.js` proxies requests to X (formerly Twitter), Instagram, Twitch and YouTube APIs. Copy `.env.example` to `.env` and provide the credentials for each service.
 
 Required environment variables:
 
@@ -15,6 +15,14 @@ Required environment variables:
 - `TWITCH_ACCESS_TOKEN`
 - `YOUTUBE_API_KEY`
 - `YOUTUBE_CHANNEL_ID`
+
+### X API endpoints
+
+The Express server provides helper routes for fetching data from the X API:
+
+- `GET /api/twitter/:username` – latest tweets from the given user.
+- `GET /api/twitter/tweet/:id/metrics` – metrics including like, retweet and reply counts for a tweet.
+- `GET /api/twitter/tweet/:id/replies` – recent replies for the tweet.
 
 ## Available Scripts
 

--- a/server/index.js
+++ b/server/index.js
@@ -61,7 +61,7 @@ app.get('/api/twitter/:username', async (req, res) => {
       return res.json(tweetsCache.data);
     }
     const tweetsResp = await fetch(
-      `https://api.twitter.com/2/users/${userId}/tweets?max_results=5`,
+      `https://api.twitter.com/2/users/${userId}/tweets?max_results=5&tweet.fields=created_at,public_metrics`,
       {
         headers: {
           Authorization: `Bearer ${BEARER_TOKEN}`,
@@ -159,6 +159,50 @@ app.get('/api/youtube', async (req, res) => {
   } catch (err) {
     console.error('Error fetching YouTube data:', err);
     res.status(500).json({ error: 'Error fetching YouTube data' });
+  }
+});
+
+// Endpoint for tweet metrics (likes, retweets, replies)
+app.get('/api/twitter/tweet/:id/metrics', async (req, res) => {
+  const tweetId = req.params.id;
+  try {
+    const resp = await fetch(
+      `https://api.twitter.com/2/tweets/${tweetId}?tweet.fields=public_metrics`,
+      {
+        headers: {
+          Authorization: `Bearer ${BEARER_TOKEN}`,
+          'User-Agent': 'juangunner4-server'
+        },
+      }
+    );
+    const json = await resp.json();
+    if (!resp.ok) return res.status(resp.status).json(json);
+    res.json(json);
+  } catch (err) {
+    console.error('Error fetching tweet metrics:', err);
+    res.status(500).json({ error: 'Error fetching tweet metrics' });
+  }
+});
+
+// Endpoint for tweet replies
+app.get('/api/twitter/tweet/:id/replies', async (req, res) => {
+  const tweetId = req.params.id;
+  try {
+    const resp = await fetch(
+      `https://api.twitter.com/2/tweets/search/recent?query=conversation_id:${tweetId}&tweet.fields=author_id,created_at&max_results=100`,
+      {
+        headers: {
+          Authorization: `Bearer ${BEARER_TOKEN}`,
+          'User-Agent': 'juangunner4-server'
+        },
+      }
+    );
+    const json = await resp.json();
+    if (!resp.ok) return res.status(resp.status).json(json);
+    res.json(json);
+  } catch (err) {
+    console.error('Error fetching tweet replies:', err);
+    res.status(500).json({ error: 'Error fetching tweet replies' });
   }
 });
 

--- a/src/components/socials/TwitterCombinedFeed.js
+++ b/src/components/socials/TwitterCombinedFeed.js
@@ -3,6 +3,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { TwitterTweetEmbed } from 'react-twitter-embed';
 import { useProfile } from '../../ProfileContext';
+import { ChatBubbleIcon, HeartIcon, LoopIcon } from '@radix-ui/react-icons';
 
 const TwitterCombinedFeed = () => {
   const { isWeb3 } = useProfile();
@@ -52,7 +53,23 @@ const TwitterCombinedFeed = () => {
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
       {tweets.map((t) => (
-        <TwitterTweetEmbed key={t.id} tweetId={t.id} options={{ conversation: 'none' }} />
+        <Box key={t.id}>
+          <TwitterTweetEmbed tweetId={t.id} options={{ conversation: 'none' }} />
+          <Box sx={{ display: 'flex', alignItems: 'center', mt: 1, ml: 1 }}>
+            <ChatBubbleIcon />
+            <Typography variant="caption" sx={{ ml: 0.5, mr: 2 }}>
+              {t.public_metrics?.reply_count}
+            </Typography>
+            <LoopIcon />
+            <Typography variant="caption" sx={{ ml: 0.5, mr: 2 }}>
+              {t.public_metrics?.retweet_count}
+            </Typography>
+            <HeartIcon />
+            <Typography variant="caption" sx={{ ml: 0.5 }}>
+              {t.public_metrics?.like_count}
+            </Typography>
+          </Box>
+        </Box>
       ))}
     </Box>
   );

--- a/src/components/socials/__tests__/TwitterCombinedFeed.test.js
+++ b/src/components/socials/__tests__/TwitterCombinedFeed.test.js
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import TwitterCombinedFeed from '../TwitterCombinedFeed';
+import { ProfileProvider } from '../../../ProfileContext';
 
 jest.mock('react-twitter-embed', () => ({
   TwitterTweetEmbed: ({ tweetId }) => <div>tweet-{tweetId}</div>,
@@ -9,7 +10,19 @@ beforeEach(() => {
   global.fetch = jest.fn(() =>
     Promise.resolve({
       ok: true,
-      json: () => Promise.resolve([{ id: '1' }, { id: '2' }]),
+      json: () =>
+        Promise.resolve({
+          data: [
+            {
+              id: '1',
+              public_metrics: { like_count: 1, retweet_count: 2, reply_count: 3 },
+            },
+            {
+              id: '2',
+              public_metrics: { like_count: 4, retweet_count: 5, reply_count: 6 },
+            },
+          ],
+        }),
     })
   );
 });
@@ -19,9 +32,16 @@ afterEach(() => {
 });
 
 test('renders tweets from API', async () => {
-  render(<TwitterCombinedFeed handles={['a', 'b']} />);
+  render(
+    <ProfileProvider>
+      <TwitterCombinedFeed />
+    </ProfileProvider>
+  );
   await waitFor(() => {
     expect(screen.getByText('tweet-1')).toBeInTheDocument();
     expect(screen.getByText('tweet-2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add tweet metrics and replies endpoints using X API
- update Twitter timeline fetch to include public metrics
- document new endpoints in README
- show tweet metrics in Twitter feed cards

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_686838e16e8c832a875dd2de41ff3f59