### PR TITLE
Remove Instagram feed title

### DIFF
--- a/src/components/socials/SocialTimeline.js
+++ b/src/components/socials/SocialTimeline.js
@@ -126,7 +126,6 @@ const SocialTimeline = ({ platform }) => {
     case 'instagram':
       content = (
         <>
-          <Typography variant="h6" align="center" sx={{ mb: 2 }}>{t('timeline.instagramTitle')}</Typography>
           <Box sx={{ position: 'relative', pb: '125%', height: 0 }}>
             <iframe
               src="https://www.instagram.com/juangunner4/embed"

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -30,7 +30,6 @@ const en = {
     development: 'In Development'
   },
   timeline: {
-    instagramTitle: 'Latest Instagram Posts',
     twitterTitle: 'Latest X (Twitter) Posts',
     twitchTitle: 'Latest Twitch Streams',
     youtubeTitle: 'Latest YouTube Videos',

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -30,7 +30,6 @@ const es = {
     development: 'En Desarrollo'
   },
   timeline: {
-    instagramTitle: 'Últimas publicaciones de Instagram',
     twitterTitle: 'Últimos posts de X (Twitter)',
     twitchTitle: 'Últimos streams de Twitch',
     youtubeTitle: 'Últimos vídeos de YouTube',


### PR DESCRIPTION
## Summary
- remove `instagramTitle` translations from locale files
- ensure SocialTimeline shows Instagram posts without heading

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68685cbafc68832a8ce8cbf8065e15d9