### PR TITLE
Fix inconsistent X feed

### DIFF
--- a/src/components/socials/SocialTimeline.js
+++ b/src/components/socials/SocialTimeline.js
@@ -117,6 +117,23 @@ const SocialTimeline = ({ platform }) => {
       })
       .catch((err) => {
         console.error(err);
+        if (platform === 'x') {
+          try {
+            const cacheKey = `tweets_${handle}`;
+            const cached = localStorage.getItem(cacheKey);
+            if (cached) {
+              const { data } = JSON.parse(cached);
+              if (data && data.length > 0) {
+                setItems(data);
+                setError(null);
+                setLoading(false);
+                return;
+              }
+            }
+          } catch (e) {
+            console.error('Error parsing tweet cache', e);
+          }
+        }
         setError(err);
         setLoading(false);
       });

--- a/src/components/socials/TwitterCombinedFeed.js
+++ b/src/components/socials/TwitterCombinedFeed.js
@@ -39,6 +39,20 @@ const TwitterCombinedFeed = () => {
         setTweets(data);
         localStorage.setItem(cacheKey, JSON.stringify({ data, timestamp: Date.now() }));
       } catch (err) {
+        try {
+          const cached = localStorage.getItem(cacheKey);
+          if (cached) {
+            const { data } = JSON.parse(cached);
+            if (data && data.length > 0) {
+              setTweets(data);
+              setError(null);
+              setLoading(false);
+              return;
+            }
+          }
+        } catch (e) {
+          console.error('Error parsing tweet cache', e);
+        }
         setError(err);
       } finally {
         setLoading(false);


### PR DESCRIPTION
## Summary
- improve X feed fallback by using cached tweets if the request fails
- use cached tweets for the combined Twitter feed when API calls fail

## Testing
- `npm test --silent --runTestsByPath src/components/socials/__tests__/TwitterCombinedFeed.test.js src/components/socials/__tests__/TwitchFeed.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68685d366080832a9d0d36ae1c6a0607