### PR TITLE
Filter projects by profile

### DIFF
--- a/src/ProfileContext.js
+++ b/src/ProfileContext.js
@@ -1,6 +1,6 @@
 import React, { createContext, useContext, useState } from 'react';
 
-const ProfileContext = createContext();
+export const ProfileContext = createContext();
 
 export const ProfileProvider = ({ children }) => {
   const [isWeb3, setIsWeb3] = useState(false);

--- a/src/pages/Projects.js
+++ b/src/pages/Projects.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import '../styles/Projects.css';
 import '@fortawesome/fontawesome-free/css/all.min.css';
 import { useTranslation } from 'react-i18next';
+import { useProfile } from '../ProfileContext';
 
 const projectData = [
   { domain: 'angelstowinghva.com', tags: ['web2', 'service'] },
@@ -28,6 +29,15 @@ const Projects = () => {
   const [view, setView] = useState('production');
   const [openProject, setOpenProject] = useState(null);
   const { t } = useTranslation();
+  const { isWeb3 } = useProfile();
+
+  const filteredProjectData = projectData.filter((p) =>
+    isWeb3 ? p.tags.includes('web3') : p.tags.includes('web2')
+  );
+
+  const filteredDevProjectData = devProjectData.filter((p) =>
+    isWeb3 ? p.tags.includes('web3') : p.tags.includes('web2')
+  );
 
   return (
     <div className="projects-page">
@@ -48,7 +58,7 @@ const Projects = () => {
       </div>
       {view === 'production' && (
         <div className="projects-container">
-          {projectData.map((project, index) => (
+          {filteredProjectData.map((project, index) => (
             <div key={index} className="project-card">
               <a
                 href={`https://${project.domain}`}
@@ -75,7 +85,7 @@ const Projects = () => {
 
       {view === 'development' && (
         <div className="projects-container">
-          {devProjectData.map((project, index) => (
+          {filteredDevProjectData.map((project, index) => (
             <div
               key={index}
               className="project-card"
@@ -106,10 +116,10 @@ const Projects = () => {
             <button className="close-btn" onClick={() => setOpenProject(null)}>
               &times;
             </button>
-            <h3>{devProjectData[openProject].name}</h3>
+            <h3>{filteredDevProjectData[openProject].name}</h3>
             <div className="env-icons">
               <a
-                href={devProjectData[openProject].environments.dev}
+                href={filteredDevProjectData[openProject].environments.dev}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="env-icon"
@@ -117,7 +127,7 @@ const Projects = () => {
                 <i className="fas fa-wrench" /> Dev
               </a>
               <a
-                href={devProjectData[openProject].environments.test}
+                href={filteredDevProjectData[openProject].environments.test}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="env-icon"

--- a/src/pages/__tests__/Projects.test.js
+++ b/src/pages/__tests__/Projects.test.js
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import Projects from '../Projects';
+import { ProfileContext } from '../../ProfileContext';
+import '../../i18n';
+
+const renderWithProfile = (isWeb3) =>
+  render(
+    <ProfileContext.Provider value={{ isWeb3, toggleProfile: jest.fn() }}>
+      <Projects />
+    </ProfileContext.Provider>
+  );
+
+test('shows only web2 projects by default', () => {
+  renderWithProfile(false);
+  expect(screen.getByText(/angelstowinghva.com/i)).toBeInTheDocument();
+  expect(screen.queryByText(/perionsol.xyz/i)).toBeNull();
+});
+
+test('shows web3 projects when profile toggled', () => {
+  renderWithProfile(true);
+  expect(screen.getByText(/perionsol.xyz/i)).toBeInTheDocument();
+  expect(screen.queryByText(/angelstowinghva.com/i)).toBeNull();
+});


### PR DESCRIPTION
## Summary
- export `ProfileContext` for easier testing
- filter production and development projects based on profile mode
- update side panel to use filtered data
- add tests for project filtering

## Testing
- `npm test -- -u --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_686fcdbea024832ab193e72c8943aff8