### PR TITLE
Update Alexandria Reds soccer end date

### DIFF
--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -30,7 +30,7 @@ const experiences = [
     title: "UPSL Soccer Player",
     company: "Alexandria Reds",
     location: "Alexandria, Virginia, United States",
-    date: "Apr 2025 - Present",
+    date: "Apr 2025 - Aug 2025",
     description: "Midfielder and OutsideBack of the Semi-pro Alexandria Reds team.",
     skills: ["Football", "Leadership", "Soccer"],
     logo: alexandrialogo,


### PR DESCRIPTION
## Summary
- update Alexandria Reds soccer resume entry to end in Aug 2025

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ad13abfdac832a9cfbc40a1b3ac9ed