### PR TITLE
style: make home page social feeds mobile friendly

### DIFF
--- a/src/components/socials/SocialTimeline.js
+++ b/src/components/socials/SocialTimeline.js
@@ -276,14 +276,20 @@ const SocialTimeline = ({ platform }) => {
             )}
             {!loading && !error &&
               items.map((v) => (
-                <Box key={v.id.videoId || v.id} sx={{ mb: 2 }}>
+                <Box key={v.id.videoId || v.id} sx={{ mb: 2, position: 'relative', pt: '56.25%' }}>
                   <iframe
-                    width="400"
-                    height="225"
                     src={`https://www.youtube.com/embed/${v.id.videoId || v.id}`}
                     allow="autoplay; encrypted-media"
                     allowFullScreen
-                    style={{ borderRadius: 8, border: 'none' }}
+                    style={{
+                      borderRadius: 8,
+                      border: 'none',
+                      position: 'absolute',
+                      top: 0,
+                      left: 0,
+                      width: '100%',
+                      height: '100%'
+                    }}
                     title={v.snippet?.title || 'YouTube video'}
                   />
                 </Box>

--- a/src/components/socials/TwitchFeed.js
+++ b/src/components/socials/TwitchFeed.js
@@ -50,15 +50,22 @@ const TwitchFeed = () => {
       <Card sx={{ my: 2, width: '100%' }}>
         <CardContent sx={{ textAlign: 'center' }}>
           <Typography variant="h6">Latest Twitch Stream</Typography>
-          <iframe
-            title={latest.title}
-            width="100%"
-            height="315"
-            src={`https://player.twitch.tv/?video=${latest.id}&parent=${window.location.hostname}`}
-            allowFullScreen
-            frameBorder="0"
-            style={{ borderRadius: 8 }}
-          />
+          <Box sx={{ position: 'relative', pt: '56.25%' }}>
+            <iframe
+              title={latest.title}
+              src={`https://player.twitch.tv/?video=${latest.id}&parent=${window.location.hostname}`}
+              allowFullScreen
+              frameBorder="0"
+              style={{
+                borderRadius: 8,
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                height: '100%'
+              }}
+            />
+          </Box>
         </CardContent>
       </Card>
       {previous.length > 0 && (
@@ -94,3 +101,4 @@ const TwitchFeed = () => {
 };
 
 export default TwitchFeed;
+

--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -7,6 +7,7 @@ import InstagramFeed from '../components/socials/InstagramFeed';
 import TwitchFeed from '../components/socials/TwitchFeed';
 import YoutubeFeed from '../components/socials/YoutubeFeed';
 import PumpFunFeed from '../components/socials/PumpFunFeed';
+import '../styles/Home.css';
 
 const VALID_TABS = ['x', 'instagram', 'twitch', 'pumpfun', 'youtube'];
 const Home = () => {
@@ -39,3 +40,4 @@ const Home = () => {
 };
 
 export default Home;
+

--- a/src/styles/Home.css
+++ b/src/styles/Home.css
@@ -1,0 +1,17 @@
+.home-page {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 0 16px;
+}
+
+.home-page iframe {
+  max-width: 100%;
+}
+
+@media (max-width: 600px) {
+  .home-page {
+    padding: 0 8px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- add Home page stylesheet and import it
- make Twitch stream and YouTube timeline responsive for small screens

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ad1d55d770832ab508954c8a8c3041