### PR TITLE
Ensure social tabs are usable on mobile

### DIFF
--- a/src/components/__tests__/SocialTabs.test.js
+++ b/src/components/__tests__/SocialTabs.test.js
@@ -1,9 +1,13 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import SocialTabs from '../socials/SocialTabs';
 import { ProfileProvider } from '../../ProfileContext';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import '../../i18n';
 
+jest.mock('@mui/material/useMediaQuery');
+
 test('calls setValue when different tab selected', () => {
+  useMediaQuery.mockReturnValue(false);
   const setValue = jest.fn();
   render(
     <ProfileProvider>
@@ -12,4 +16,16 @@ test('calls setValue when different tab selected', () => {
   );
   fireEvent.click(screen.getByRole('tab', { name: /instagram/i }));
   expect(setValue).toHaveBeenCalledWith('instagram');
+});
+
+test('renders scrollable tabs on small screens', () => {
+  useMediaQuery.mockReturnValue(true);
+  const setValue = jest.fn();
+  const { container } = render(
+    <ProfileProvider>
+      <SocialTabs value="x" setValue={setValue} />
+    </ProfileProvider>
+  );
+  const tabsRoot = container.querySelector('.MuiTabs-root');
+  expect(tabsRoot.className).not.toMatch(/MuiTabs-centered/);
 });

--- a/src/components/socials/SocialTabs.js
+++ b/src/components/socials/SocialTabs.js
@@ -4,11 +4,13 @@ import PropTypes from 'prop-types';
 import Box from '@mui/material/Box';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
+import useMediaQuery from '@mui/material/useMediaQuery';
 import { useTranslation } from 'react-i18next';
 import { SportsEsports, LocalFireDepartment, YouTube } from '@mui/icons-material';
 
 const SocialTabs = ({ value, setValue }) => {
   const { t } = useTranslation();
+  const isMobile = useMediaQuery('(max-width:700px)');
   const handleChange = (event, newValue) => {
     setValue(newValue);
   };
@@ -26,10 +28,13 @@ const SocialTabs = ({ value, setValue }) => {
       }}
     >
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <Tabs 
-          value={value} 
-          onChange={handleChange} 
-          centered
+        <Tabs
+          value={value}
+          onChange={handleChange}
+          centered={!isMobile}
+          variant={isMobile ? 'scrollable' : 'standard'}
+          scrollButtons={isMobile ? 'auto' : false}
+          allowScrollButtonsMobile
           aria-label="social media tabs"
           sx={{
             '& .MuiTab-root': {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,19 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+
+// Polyfill matchMedia for components using useMediaQuery (e.g., SocialTabs)
+// jest does not implement this API by default
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});


### PR DESCRIPTION
## Summary
- make social tabs scrollable on viewports 700px or less
- polyfill matchMedia for tests
- verify social tabs adjust layout on small screens

## Testing
- `CI=true npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68ad3bd8f6b4832aa8fea269ee13b1a7