### PR TITLE
Add FootballCoin to Web3 development projects

### DIFF
--- a/src/pages/Projects.js
+++ b/src/pages/Projects.js
@@ -24,6 +24,15 @@ const devProjectData = [
       test: 'https://primos-marketplace.onrender.com/',
     },
   },
+  {
+    name: 'footballcoin.fun',
+    logo: 'https://footballcoin.fun/favicon.ico',
+    tags: ['web3'],
+    environments: {
+      dev: 'https://website-07c113b9.ehn.vdj.temporary.site/',
+      test: 'https://footballcoin.fun',
+    },
+  },
 ];
 
 const Projects = () => {


### PR DESCRIPTION
## Summary
- list FootballCoin development site alongside Primos in Web3 projects

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0f2aa2548832aaaae6853bb8c2ab3