### PR TITLE
Ensure hero CTA uses client-side routing

### DIFF
--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -6,6 +6,7 @@ import '@fortawesome/fontawesome-free/css/all.min.css';
 import '../styles/Hero.css';
 import { useProfile } from '../ProfileContext';
 import { useTranslation, Trans } from 'react-i18next';
+import { Link } from 'react-router-dom';
 
 const Hero = () => {
   const { isWeb3 } = useProfile();
@@ -29,7 +30,12 @@ const Hero = () => {
           }} />
         </Typography>
       )}
-      <Button variant="contained" href="/projects" className="project-button">
+      <Button
+        variant="contained"
+        component={Link}
+        to="/projects"
+        className="project-button"
+      >
         {t('hero.viewProjects')}
       </Button>
     </Box>

--- a/src/components/__tests__/Hero.test.js
+++ b/src/components/__tests__/Hero.test.js
@@ -1,13 +1,16 @@
 import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
 import Hero from '../Hero';
 import { ProfileProvider } from '../../ProfileContext';
 import '../../i18n';
 
 test('renders hero section', () => {
   render(
-    <ProfileProvider>
-      <Hero />
-    </ProfileProvider>
+    <MemoryRouter>
+      <ProfileProvider>
+        <Hero />
+      </ProfileProvider>
+    </MemoryRouter>
   );
   expect(screen.getByText(/welcome/i)).toBeInTheDocument();
   expect(screen.getByText(/my name is juan/i)).toBeInTheDocument();


### PR DESCRIPTION
## Summary
- update the hero "View Projects" button to use react-router navigation
- wrap the hero test in MemoryRouter so Link has routing context

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68cb1b80aff4832a83657c1b26dab0c2