### PR TITLE
Align trade sections with profile context

### DIFF
--- a/src/ProfileContext.js
+++ b/src/ProfileContext.js
@@ -1,14 +1,19 @@
 import React, { createContext, useContext, useState } from 'react';
 
-export const ProfileContext = createContext();
+export const ProfileContext = createContext({
+  isWeb3: false,
+  toggleProfile: () => {},
+  setProfile: () => {},
+});
 
 export const ProfileProvider = ({ children }) => {
   const [isWeb3, setIsWeb3] = useState(false);
 
   const toggleProfile = () => setIsWeb3((prev) => !prev);
+  const setProfile = (value) => setIsWeb3(Boolean(value));
 
   return (
-    <ProfileContext.Provider value={{ isWeb3, toggleProfile }}>
+    <ProfileContext.Provider value={{ isWeb3, toggleProfile, setProfile }}>
       {children}
     </ProfileContext.Provider>
   );

--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -32,8 +32,8 @@ const en = {
     software: 'Software Engineer',
     soccer: 'Football/Soccer',
     tradeTabs: {
-      web2: 'Trade (Web2 Stocks)',
-      web3: 'Trade (Web3 Crypto)',
+      invest: 'Invest with Me',
+      trade: 'Trade with Me',
     },
     trade: {
       referralCodeLabel: 'Referral Code',
@@ -41,10 +41,10 @@ const en = {
       copied: 'Copied!',
       copyError: 'Unable to copy automatically. Please use the code manually.',
       categories: {
-        web2: {
-          heading: 'Build Wealth with Stock Brokerages',
+        invest: {
+          heading: 'Invest with Me',
           description:
-            'Tap into the brokerages I trust for equities and options. Use these invite links to claim free stock rewards and level up your Web2 portfolio.',
+            'Tap into the brokerages I trust for equities and options. Use these invite links to claim free stock rewards and grow your portfolio.',
           platforms: {
             webull: {
               name: 'Webull Financial',
@@ -54,10 +54,10 @@ const en = {
             },
           },
         },
-        web3: {
-          heading: 'Explore Crypto Exchanges I Use Daily',
+        trade: {
+          heading: 'Trade with Me',
           description:
-            'These crypto-native platforms power my on-chain strategies. Sign up with my links to receive trading perks while supporting the journey.',
+            'These on-chain platforms power my trading strategies. Sign up with my links to receive perks while supporting the journey.',
           platforms: {
             coinbase: {
               name: 'Coinbase Advanced',

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -32,8 +32,8 @@ const es = {
     software: 'Ingeniero de Software',
     soccer: 'Fútbol',
     tradeTabs: {
-      web2: 'Trading (Web2 Acciones)',
-      web3: 'Trading (Web3 Cripto)',
+      invest: 'Invierte conmigo',
+      trade: 'Opera conmigo',
     },
     trade: {
       referralCodeLabel: 'Código de referido',
@@ -41,10 +41,10 @@ const es = {
       copied: '¡Copiado!',
       copyError: 'No se pudo copiar automáticamente. Usa el código manualmente.',
       categories: {
-        web2: {
-          heading: 'Haz crecer tu portafolio con brókers de acciones',
+        invest: {
+          heading: 'Invierte conmigo',
           description:
-            'Aprovecha los brókers que uso para operar acciones y opciones. Usa estos enlaces para reclamar acciones gratis y potenciar tu portafolio Web2.',
+            'Aprovecha los brókers que uso para operar acciones y opciones. Usa estos enlaces para reclamar acciones gratis y hacer crecer tu portafolio.',
           platforms: {
             webull: {
               name: 'Webull Financial',
@@ -54,10 +54,10 @@ const es = {
             },
           },
         },
-        web3: {
-          heading: 'Explora los exchanges de cripto que uso a diario',
+        trade: {
+          heading: 'Opera conmigo',
           description:
-            'Estas plataformas nativas cripto impulsan mis estrategias on-chain. Regístrate con mis enlaces para recibir beneficios y apoyar mi trabajo.',
+            'Estas plataformas on-chain impulsan mis estrategias. Regístrate con mis enlaces para recibir beneficios y apoyar mi trabajo.',
           platforms: {
             coinbase: {
               name: 'Coinbase Advanced',

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -16,6 +16,7 @@ import coinbaseLogo from '../assets/coinbase.svg';
 import binanceLogo from '../assets/binance.svg';
 import webullLogo from '../assets/webull.svg';
 import { useTranslation } from 'react-i18next';
+import { useProfile } from '../ProfileContext';
 
 
 const experiences = [
@@ -204,7 +205,7 @@ const experiences = [
 ];
 
 const tradingPlatforms = {
-  web2: [
+  invest: [
     {
       id: 'webull',
       logo: webullLogo,
@@ -212,7 +213,7 @@ const tradingPlatforms = {
       code: 'JUANWEBULL',
     },
   ],
-  web3: [
+  trade: [
     {
       id: 'coinbase',
       logo: coinbaseLogo,
@@ -233,7 +234,18 @@ const About = () => {
   const [copyStatus, setCopyStatus] = useState({ code: '', error: false });
   const copyTimeoutRef = useRef(null);
   const { t } = useTranslation();
-  const tradeCategories = ['web2', 'web3'];
+  const { isWeb3, setProfile } = useProfile();
+  const tradeCategories = ['invest', 'trade'];
+  const tradeCategoryForProfile = isWeb3 ? 'trade' : 'invest';
+
+  useEffect(() => {
+    setSelectedCategory((previousCategory) =>
+      tradeCategories.includes(previousCategory)
+        ? tradeCategoryForProfile
+        : previousCategory,
+    );
+  }, [tradeCategoryForProfile]);
+
   const isTradeCategory = tradeCategories.includes(selectedCategory);
   const filteredExperiences = isTradeCategory
     ? []
@@ -254,6 +266,16 @@ const About = () => {
       }
     };
   }, []);
+
+  const handleCategorySelect = (category) => {
+    setSelectedCategory(category);
+
+    if (category === 'invest') {
+      setProfile(false);
+    } else if (category === 'trade') {
+      setProfile(true);
+    }
+  };
 
   const handleCopyCode = (code) => {
     const markSuccess = () => {
@@ -299,6 +321,10 @@ const About = () => {
     fallbackCopy();
   };
 
+  const tradeSectionClass = isTradeCategory
+    ? `trade-section trade-section--${selectedCategory}`
+    : '';
+
   return (
     <div className="about-page">
       <h2>{t('about.heading')}</h2>
@@ -306,34 +332,34 @@ const About = () => {
         <button
           className={`event-btn ${selectedCategory === 'software' ? 'active' : ''
             }`}
-          onClick={() => setSelectedCategory('software')}
+          onClick={() => handleCategorySelect('software')}
         >
           {t('about.software')}
         </button>
         <button
           className={`event-btn ${selectedCategory === 'soccer' ? 'active' : ''
             }`}
-          onClick={() => setSelectedCategory('soccer')}
+          onClick={() => handleCategorySelect('soccer')}
         >
           {t('about.soccer')}
         </button>
         <button
-          className={`event-btn ${selectedCategory === 'web2' ? 'active' : ''
+          className={`event-btn ${selectedCategory === 'invest' ? 'active' : ''
             }`}
-          onClick={() => setSelectedCategory('web2')}
+          onClick={() => handleCategorySelect('invest')}
         >
-          {t('about.tradeTabs.web2')}
+          {t('about.tradeTabs.invest')}
         </button>
         <button
-          className={`event-btn ${selectedCategory === 'web3' ? 'active' : ''
+          className={`event-btn ${selectedCategory === 'trade' ? 'active' : ''
             }`}
-          onClick={() => setSelectedCategory('web3')}
+          onClick={() => handleCategorySelect('trade')}
         >
-          {t('about.tradeTabs.web3')}
+          {t('about.tradeTabs.trade')}
         </button>
       </div>
       {isTradeCategory ? (
-        <section className="trade-section">
+        <section className={tradeSectionClass}>
           <h3>{t(`about.trade.categories.${selectedCategory}.heading`)}</h3>
           <p className="trade-description">
             {t(`about.trade.categories.${selectedCategory}.description`)}


### PR DESCRIPTION
## Summary
- remove the Web2/Web3 wording from the trade tab labels and headings in both locales
- drive the About page trade section from the profile context so Web2/Web3 selections show the matching referral block

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68d5ff39e684832aa984d7c3b749f132