### PR TITLE
Fix lint warning in About page trade category effect

### DIFF
--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -204,6 +204,8 @@ const experiences = [
   },
 ];
 
+const TRADE_CATEGORIES = ['invest', 'trade'];
+
 const tradingPlatforms = {
   invest: [
     {
@@ -235,18 +237,17 @@ const About = () => {
   const copyTimeoutRef = useRef(null);
   const { t } = useTranslation();
   const { isWeb3, setProfile } = useProfile();
-  const tradeCategories = ['invest', 'trade'];
   const tradeCategoryForProfile = isWeb3 ? 'trade' : 'invest';
 
   useEffect(() => {
     setSelectedCategory((previousCategory) =>
-      tradeCategories.includes(previousCategory)
+      TRADE_CATEGORIES.includes(previousCategory)
         ? tradeCategoryForProfile
         : previousCategory,
     );
   }, [tradeCategoryForProfile]);
 
-  const isTradeCategory = tradeCategories.includes(selectedCategory);
+  const isTradeCategory = TRADE_CATEGORIES.includes(selectedCategory);
   const filteredExperiences = isTradeCategory
     ? []
     : experiences.filter((exp) => exp.category === selectedCategory);


### PR DESCRIPTION
## Summary
- define the trade categories list at module scope so the About page hook can safely reference it
- update the hook logic to use the shared constant and avoid the missing dependency warning during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6ebcc0204832aa02d3702d2044f48