### PR TITLE
Expand web2 floating messages

### DIFF
--- a/src/components/Navbar.js
+++ b/src/components/Navbar.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import Drawer from '@mui/material/Drawer';
 import List from '@mui/material/List';
@@ -14,11 +14,60 @@ const Navbar = () => {
   const { isWeb3, toggleProfile } = useProfile();
   const currentImage = isWeb3 ? web3Image : web2Image;
   const [drawerOpen, setDrawerOpen] = useState(false);
+  const [floatingMessage, setFloatingMessage] = useState(null);
   const { t, i18n } = useTranslation();
 
   const toggleDrawer = (open) => () => {
     setDrawerOpen(open);
   };
+
+  useEffect(() => {
+    const web2Messages = [
+      'Hi',
+      'Click me',
+      'Come on you gunners',
+      'Trakas',
+      'Odiame Mas',
+      'Arriba las Aguilas',
+    ];
+    const web3Messages = ['GmGn', '$JUAN', '$troll', '$peri', '$sns', '$doggy', '$mask'];
+    const sequence = isWeb3 ? web3Messages : web2Messages;
+
+    if (sequence.length === 0) return undefined;
+
+    let index = 0;
+    let intervalId = null;
+    let removalTimeoutId = null;
+
+    const showNext = () => {
+      const message = sequence[index];
+      setFloatingMessage({
+        value: message,
+        key: `${isWeb3 ? 'web3' : 'web2'}-${index}-${Date.now()}`,
+      });
+      index += 1;
+
+      if (index >= sequence.length) {
+        if (intervalId) clearInterval(intervalId);
+        removalTimeoutId = setTimeout(() => {
+          setFloatingMessage(null);
+        }, 2000);
+      }
+    };
+
+    showNext();
+    intervalId = setInterval(() => {
+      if (index < sequence.length) {
+        showNext();
+      }
+    }, 2000);
+
+    return () => {
+      if (intervalId) clearInterval(intervalId);
+      if (removalTimeoutId) clearTimeout(removalTimeoutId);
+      setFloatingMessage(null);
+    };
+  }, [isWeb3]);
 
   return (
     <nav className="navbar">
@@ -36,6 +85,11 @@ const Navbar = () => {
               className="navbar-pfp"
               draggable="false"
             />
+            {floatingMessage && (
+              <span key={floatingMessage.key} className="pfp-float-text">
+                {floatingMessage.value}
+              </span>
+            )}
             <span className="pfp-tag">{isWeb3 ? t('navbar.web3') : t('navbar.web2')}</span>
           </div>
         </button>

--- a/src/styles/Navbar.css
+++ b/src/styles/Navbar.css
@@ -29,6 +29,7 @@
 .pfp-wrapper {
     position: relative;
     display: inline-block;
+    overflow: visible;
 }
 
 .pfp-tag {
@@ -41,6 +42,37 @@
     padding: 2px 4px;
     font-size: 10px;
     font-weight: bold;
+}
+
+.pfp-float-text {
+    position: absolute;
+    left: 50%;
+    bottom: 10px;
+    transform: translate(-50%, 20px);
+    color: #ffffff;
+    font-weight: 700;
+    text-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
+    pointer-events: none;
+    white-space: nowrap;
+    animation: pfpFloatUp 2s ease forwards;
+}
+
+@keyframes pfpFloatUp {
+    0% {
+        opacity: 0;
+        transform: translate(-50%, 20px);
+    }
+    15% {
+        opacity: 1;
+    }
+    85% {
+        opacity: 0;
+        transform: translate(-50%, -30px);
+    }
+    100% {
+        opacity: 0;
+        transform: translate(-50%, -30px);
+    }
 }
 
 .navbar-right {


### PR DESCRIPTION
## Summary
- add timed floating text sequences for web2 and web3 profile avatars
- style floating messages to animate upward and fade out over each two-second display
- extend the web2 floating message rotation with additional slogans and correct the gunners chant wording

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68d6fbe4abbc832a9bb2f7c123f3407c