### PR TITLE
Adjust navbar floating messages for mobile

### DIFF
--- a/src/styles/Navbar.css
+++ b/src/styles/Navbar.css
@@ -53,7 +53,7 @@
     font-weight: 700;
     text-shadow: 0 2px 6px rgba(0, 0, 0, 0.4);
     pointer-events: none;
-    max-width: clamp(80px, 25vw, 100px);
+    max-width: clamp(90px, 28vw, 120px);
     padding: 6px 10px;
     box-sizing: border-box;
     border-radius: 12px;
@@ -61,6 +61,8 @@
     text-align: center;
     white-space: normal;
     word-break: break-word;
+    font-size: 12px;
+    line-height: 1.2;
     animation: pfpFloatUp 4s ease forwards;
 }
 
@@ -151,5 +153,22 @@
 
     .desktop-lang {
         display: none;
+    }
+
+    .pfp-float-text {
+        bottom: 6px;
+        padding: 4px 8px;
+        font-size: 11px;
+        max-width: clamp(80px, 40vw, 140px);
+    }
+}
+
+@media (max-width: 480px) {
+    .pfp-float-text {
+        bottom: 4px;
+        padding: 3px 6px;
+        font-size: 10px;
+        max-width: clamp(70px, 55vw, 150px);
+        border-radius: 10px;
     }
 }


### PR DESCRIPTION
## Summary
- tweak the floating profile message sizing so it scales more gracefully on small screens
- add responsive font and padding adjustments to keep the web2/web3 labels readable on mobile

## Testing
- npm run client

------
https://chatgpt.com/codex/tasks/task_e_68d722a23464832a9d6585176aa51dc1