### PR TITLE
Revamp referral listings with placeholder tags

### DIFF
--- a/src/locales/en.js
+++ b/src/locales/en.js
@@ -37,6 +37,7 @@ const en = {
     },
     trade: {
       referralCodeLabel: 'Referral Code',
+      tagsLabel: 'Tags',
       copyCode: 'Copy code',
       copied: 'Copied!',
       copyError: 'Unable to copy automatically. Please use the code manually.',
@@ -52,6 +53,18 @@ const en = {
                 'Advanced charting, extended-hours trading, and multi-asset support tailored for active investors.',
               linkLabel: 'Unlock your Webull bonus',
             },
+            cashapp: {
+              name: 'Cash App',
+              description:
+                'Send, spend, and invest seamlessly with instant transfers and fractional stock investing.',
+              linkLabel: 'Join Cash App with my link',
+            },
+            sofi: {
+              name: 'SoFi Money',
+              description:
+                'A hybrid checking and savings experience with automated investing and member benefits.',
+              linkLabel: 'Activate your SoFi bonus',
+            },
           },
         },
         trade: {
@@ -59,17 +72,53 @@ const en = {
           description:
             'These on-chain platforms power my trading strategies. Sign up with my links to receive perks while supporting the journey.',
           platforms: {
+            okx: {
+              name: 'OKX',
+              description:
+                'A global crypto hub with deep liquidity, powerful charting, and pro-grade derivatives trading.',
+              linkLabel: 'Start trading on OKX',
+            },
+            ourbit: {
+              name: 'Ourbit',
+              description:
+                'Simplified perpetuals and structured products designed for high-velocity crypto strategies.',
+              linkLabel: 'Explore Ourbit',
+            },
+            aster: {
+              name: 'Aster',
+              description:
+                'Curated web3 trading access with managed vaults and real-time analytics.',
+              linkLabel: 'Discover Aster',
+            },
             coinbase: {
               name: 'Coinbase Advanced',
               description:
                 'Institutional-grade charts, deep liquidity, and robust security for active crypto traders.',
               linkLabel: 'Activate Coinbase referral',
             },
-            binance: {
-              name: 'Binance Global',
+            axiom: {
+              name: 'Axiom',
               description:
-                'Low-fee spot and futures trading with access to hundreds of crypto pairs and earning products.',
-              linkLabel: 'Join Binance with my code',
+                'Copy, mirror, and automate strategies across top decentralized exchanges from one dashboard.',
+              linkLabel: 'Trade with Axiom',
+            },
+            backpack: {
+              name: 'Backpack Exchange',
+              description:
+                'A community-driven exchange featuring smart order routing and xNFT wallet integration.',
+              linkLabel: 'Join Backpack Exchange',
+            },
+            drip: {
+              name: 'Drip',
+              description:
+                'Support creators and unlock exclusive drops with streamlined Solana-native payments.',
+              linkLabel: 'Collect on Drip',
+            },
+            sns: {
+              name: 'SNS',
+              description:
+                'Discover emerging Solana projects with curated mints, data insights, and launchpad tooling.',
+              linkLabel: 'Explore SNS',
             },
           },
         },

--- a/src/locales/es.js
+++ b/src/locales/es.js
@@ -37,6 +37,7 @@ const es = {
     },
     trade: {
       referralCodeLabel: 'Código de referido',
+      tagsLabel: 'Etiquetas',
       copyCode: 'Copiar código',
       copied: '¡Copiado!',
       copyError: 'No se pudo copiar automáticamente. Usa el código manualmente.',
@@ -52,6 +53,18 @@ const es = {
                 'Gráficos avanzados, trading en horario extendido y soporte multi-activo para inversores activos.',
               linkLabel: 'Obtén tu bono de Webull',
             },
+            cashapp: {
+              name: 'Cash App',
+              description:
+                'Envía, gasta e invierte al instante con transferencias inmediatas e inversión fraccionada en acciones.',
+              linkLabel: 'Únete a Cash App con mi enlace',
+            },
+            sofi: {
+              name: 'SoFi Money',
+              description:
+                'Una cuenta híbrida de cheques y ahorros con inversión automatizada y beneficios para miembros.',
+              linkLabel: 'Activa tu bono de SoFi',
+            },
           },
         },
         trade: {
@@ -59,17 +72,53 @@ const es = {
           description:
             'Estas plataformas on-chain impulsan mis estrategias. Regístrate con mis enlaces para recibir beneficios y apoyar mi trabajo.',
           platforms: {
+            okx: {
+              name: 'OKX',
+              description:
+                'Un hub cripto global con gran liquidez, gráficos potentes y derivados de nivel profesional.',
+              linkLabel: 'Comienza a operar en OKX',
+            },
+            ourbit: {
+              name: 'Ourbit',
+              description:
+                'Perpetuos y productos estructurados simplificados para estrategias cripto de alta velocidad.',
+              linkLabel: 'Explora Ourbit',
+            },
+            aster: {
+              name: 'Aster',
+              description:
+                'Acceso curado a trading web3 con bóvedas gestionadas y analíticas en tiempo real.',
+              linkLabel: 'Descubre Aster',
+            },
             coinbase: {
               name: 'Coinbase Advanced',
               description:
                 'Gráficos profesionales, liquidez profunda y seguridad robusta para traders activos de cripto.',
               linkLabel: 'Activa el referido de Coinbase',
             },
-            binance: {
-              name: 'Binance Global',
+            axiom: {
+              name: 'Axiom',
               description:
-                'Comisiones bajas en spot y futuros con acceso a cientos de pares y productos de rendimiento.',
-              linkLabel: 'Únete a Binance con mi código',
+                'Copia, refleja y automatiza estrategias en los principales DEX desde un solo panel.',
+              linkLabel: 'Opera con Axiom',
+            },
+            backpack: {
+              name: 'Backpack Exchange',
+              description:
+                'Un exchange impulsado por la comunidad con enrutamiento inteligente y billetera xNFT integrada.',
+              linkLabel: 'Únete a Backpack Exchange',
+            },
+            drip: {
+              name: 'Drip',
+              description:
+                'Apoya a creadores y desbloquea lanzamientos exclusivos con pagos nativos de Solana.',
+              linkLabel: 'Colecciona en Drip',
+            },
+            sns: {
+              name: 'SNS',
+              description:
+                'Descubre proyectos emergentes de Solana con mints curados, datos y herramientas de lanzamiento.',
+              linkLabel: 'Explora SNS',
             },
           },
         },

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -13,8 +13,9 @@ import mthreeLogo from '../assets/mthree.jpg';
 import emuLogo from '../assets/emu.png';
 import horizonsedgelogo from '../assets/horizonsedgelogo.png';
 import coinbaseLogo from '../assets/coinbase.svg';
-import binanceLogo from '../assets/binance.svg';
 import webullLogo from '../assets/webull.svg';
+import web3Placeholder from '../assets/web3.jpg';
+import profilePlaceholder from '../assets/profile.png';
 import { useTranslation } from 'react-i18next';
 import { useProfile } from '../ProfileContext';
 
@@ -211,22 +212,70 @@ const tradingPlatforms = {
     {
       id: 'webull',
       logo: webullLogo,
-      link: 'https://a.webull.com/i/JuanGunner',
-      code: 'JUANWEBULL',
+      link: 'https://a.webull.com/NMixfRYZu7bzStLzxT',
+      tags: ['Tag TBD'],
+    },
+    {
+      id: 'cashapp',
+      link: 'https://cash.app/app/BWSDDQZ',
+      tags: ['Tag TBD'],
+      logo: profilePlaceholder,
+    },
+    {
+      id: 'sofi',
+      link: 'https://www.sofi.com/invite/money?gcp=3972bc11-fd65-4573-8eca-5afb3831d790&isAliasGcp=false',
+      tags: ['Tag TBD'],
+      logo: profilePlaceholder,
     },
   ],
   trade: [
     {
-      id: 'coinbase',
-      logo: coinbaseLogo,
-      link: 'https://www.coinbase.com/join?code=JUANCOINBASE',
-      code: 'JUANCOINBASE',
+      id: 'okx',
+      link: 'https://t.co/bgPKR6NG0R',
+      tags: ['Tag TBD'],
+      logo: web3Placeholder,
     },
     {
-      id: 'binance',
-      logo: binanceLogo,
-      link: 'https://accounts.binance.com/en/register?ref=JUANGUNNER',
-      code: 'JUANGUNNER',
+      id: 'ourbit',
+      link: 'https://t.co/bVED6Lt670',
+      tags: ['Tag TBD'],
+      logo: web3Placeholder,
+    },
+    {
+      id: 'aster',
+      link: 'https://t.co/2Vp8ELVY5W',
+      tags: ['Tag TBD'],
+      logo: web3Placeholder,
+    },
+    {
+      id: 'coinbase',
+      logo: coinbaseLogo,
+      link: 'https://coinbase.onelink.me/2ysS/rx5ndund?src=ios-link',
+      tags: ['Tag TBD'],
+    },
+    {
+      id: 'axiom',
+      link: 'https://axiom.trade/@0x1juan',
+      tags: ['Tag TBD'],
+      logo: web3Placeholder,
+    },
+    {
+      id: 'backpack',
+      link: 'https://backpack.exchange/refer/4tji5qyt',
+      tags: ['Tag TBD'],
+      logo: web3Placeholder,
+    },
+    {
+      id: 'drip',
+      link: 'https://drip.market/?ref=juangunner4',
+      tags: ['Tag TBD'],
+      logo: web3Placeholder,
+    },
+    {
+      id: 'sns',
+      link: 'https://www.sns.id?ref=juangunner4',
+      tags: ['Tag TBD'],
+      logo: web3Placeholder,
     },
   ],
 };
@@ -373,20 +422,46 @@ const About = () => {
           </p>
           <div className="referrals-grid">
             {(tradingPlatforms[selectedCategory] || []).map((platform) => {
-              const isActivePlatform = copyStatus.code === platform.code;
+              const isActivePlatform =
+                platform.code && copyStatus.code === platform.code;
               const platformName = t(`about.trade.categories.${selectedCategory}.platforms.${platform.id}.name`);
               const platformDescription = t(`about.trade.categories.${selectedCategory}.platforms.${platform.id}.description`);
               const platformLinkLabel = t(`about.trade.categories.${selectedCategory}.platforms.${platform.id}.linkLabel`);
+              const fallbackAccessibilityProps = !platform.logo
+                ? { role: 'img', 'aria-label': `${platformName} placeholder icon` }
+                : {};
+
               return (
                 <article key={platform.id} className="referral-card">
-                  <div className="referral-logo">
-                    <img
-                      src={platform.logo}
-                      alt={`${platformName} logo`}
-                    />
+                  <div
+                    className={`referral-logo ${!platform.logo ? 'referral-logo--fallback' : ''}`}
+                    {...fallbackAccessibilityProps}
+                  >
+                    {platform.logo ? (
+                      <img
+                        src={platform.logo}
+                        alt={`${platformName} logo`}
+                      />
+                    ) : (
+                      <span aria-hidden="true">{platformName.charAt(0)}</span>
+                    )}
                   </div>
                   <h4>{platformName}</h4>
                   <p>{platformDescription}</p>
+                  {platform.tags && platform.tags.length > 0 && (
+                    <div className="referral-tags">
+                      <span className="referral-tags__label">
+                        {t('about.trade.tagsLabel')}
+                      </span>
+                      <ul>
+                        {platform.tags.map((tag) => (
+                          <li key={tag} className="referral-tag">
+                            {tag}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
                   <a
                     className="referral-link"
                     href={platform.link}
@@ -395,20 +470,22 @@ const About = () => {
                   >
                     {platformLinkLabel}
                   </a>
-                  <div className="referral-code" aria-live="polite">
-                    <span>{t('about.trade.referralCodeLabel')}</span>
-                    <code>{platform.code}</code>
-                    <button
-                      type="button"
-                      className="copy-button"
-                      onClick={() => handleCopyCode(platform.code)}
-                    >
-                      {isActivePlatform && !copyStatus.error
-                        ? t('about.trade.copied')
-                        : t('about.trade.copyCode')}
-                    </button>
-                  </div>
-                  {isActivePlatform && copyStatus.error && (
+                  {platform.code && (
+                    <div className="referral-code" aria-live="polite">
+                      <span>{t('about.trade.referralCodeLabel')}</span>
+                      <code>{platform.code}</code>
+                      <button
+                        type="button"
+                        className="copy-button"
+                        onClick={() => handleCopyCode(platform.code)}
+                      >
+                        {isActivePlatform && !copyStatus.error
+                          ? t('about.trade.copied')
+                          : t('about.trade.copyCode')}
+                      </button>
+                    </div>
+                  )}
+                  {platform.code && isActivePlatform && copyStatus.error && (
                     <p className="copy-feedback" role="status">
                       {t('about.trade.copyError')}
                     </p>

--- a/src/styles/About.css
+++ b/src/styles/About.css
@@ -157,6 +157,24 @@
     box-shadow: 0 6px 14px rgba(0, 0, 0, 0.12);
 }
 
+.referral-logo--fallback {
+    width: 56px;
+    height: 56px;
+    border-radius: 12px;
+    background: linear-gradient(135deg, #2563eb, #7c3aed);
+    color: #ffffff;
+    font-weight: 700;
+    font-size: 1.25rem;
+    justify-content: center;
+    align-items: center;
+    text-transform: uppercase;
+}
+
+.referral-logo--fallback span {
+    display: inline-block;
+    line-height: 1;
+}
+
 .referral-card h4 {
     margin: 0;
     font-size: 1.25rem;
@@ -168,6 +186,38 @@
     font-size: 0.95rem;
     line-height: 1.5;
     color: #4b5563;
+}
+
+.referral-tags {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.referral-tags__label {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #1f2937;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.referral-tags ul {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.referral-tag {
+    padding: 4px 10px;
+    border-radius: 999px;
+    background-color: rgba(37, 99, 235, 0.08);
+    color: #1d4ed8;
+    font-size: 0.8rem;
+    font-weight: 600;
 }
 
 .referral-link {


### PR DESCRIPTION
## Summary
- replace the invest and trade referral lists with updated Web2 and Web3 partners
- add placeholder tag support and fallback icons so each referral can surface future classifications
- refresh English and Spanish copy for the new platforms and tag label

## Testing
- npm run client

------
https://chatgpt.com/codex/tasks/task_e_68d73131c02c832a9dbea9c8fbc0e22b